### PR TITLE
Get docs body by group

### DIFF
--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -69,7 +69,10 @@ const getDocsBody = async (namespace: any, docs: IBookCatalog[], headers: Reques
         // 所有文档的请求
         const requests = docs
             .filter((item: IBookCatalog) => item.type === 'DOC' && !!item.url)
-            .map((item: IBookCatalog) => {
+            .map((item: IBookCatalog, index: number) => {
+                const groupIndex = Math.floor(index / 20) + 1
+                const delay = groupIndex * 1000.0
+
                 // 防止频繁请求
                 return new Promise((resolve, reject) => {
                     setTimeout(async () => {
@@ -81,7 +84,7 @@ const getDocsBody = async (namespace: any, docs: IBookCatalog[], headers: Reques
                         } catch (e) {
                             reject(e)
                         }
-                    }, 100)
+                    }, delay)
                 })
             })
         const res = await Promise.all(requests)


### PR DESCRIPTION
我有个目录下有 200 多个文件，导出这个目录下的文件时一直报 x-ratelimit-limit 错。之前的方法在 map 触发时统一延迟 200ms，然后并行请求这200多个文件，触发了语雀的 ratelimit。

现在改成将这些文件分组请求，相同组文件并行请求（20个每组），不同组之间串行延迟 1s 请求（1s, 2s, 3s, 4s...）。

我的这个目录下的文件使用修改后的方法已经可以正常导出了。